### PR TITLE
Fix ->validationErrors->count() when the object is null

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -538,9 +538,11 @@ abstract class Ardent extends Model {
 
 			if ($success) {
 				// if the model is valid, unset old errors
-				if ($this->validationErrors->count() > 0) {
-					$this->validationErrors = new MessageBag;
-				}
+				if($this->validationErrors === null){
+                    $this->validationErrors = new MessageBag;
+                }elseif($this->validationErrors->count() > 0) {
+                        $this->validationErrors = new MessageBag;
+                }
 			} else {
 				// otherwise set the new ones
 				$this->validationErrors = $this->validator->messages();

--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -539,10 +539,10 @@ abstract class Ardent extends Model {
 			if ($success) {
 				// if the model is valid, unset old errors
 				if($this->validationErrors === null){
-                    $this->validationErrors = new MessageBag;
-                }elseif($this->validationErrors->count() > 0) {
-                        $this->validationErrors = new MessageBag;
-                }
+					$this->validationErrors = new MessageBag;
+				}elseif($this->validationErrors->count() > 0) {
+					$this->validationErrors = new MessageBag;
+				}
 			} else {
 				// otherwise set the new ones
 				$this->validationErrors = $this->validator->messages();


### PR DESCRIPTION
Hi... in the **src/LaravelBook/Ardent/Ardent.php** line **541** i've found an issue: The `$this->validationErrors->count()` causes an error because `validationErrors` is null and does not retrive the `count()` method.

See this [Screenshot](http://i.imgur.com/AnI1t8u.png)

Then a single check if it's null, solve it... I do know how the object is null in my case, but here is my suggestion in this pull request.

Sorry about my poor english!

