### PR TITLE
buildUniqueExclusionRules table name bugfix.

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -795,7 +795,7 @@ abstract class Ardent extends Model {
                 // Append table name if needed
                 $table = explode(':', $params[0]);
                 if (count($table) == 1)
-                  $uniqueRules[1] = $this->table;
+                  $uniqueRules[1] = $this->getTable();
                 else
                   $uniqueRules[1] = $table[1];
                


### PR DESCRIPTION
Ardent breaks unique rules update if table name is implicity (e.g. **without** a explicit `$table` property). This PR fixes this behavior using `$this->getTable()` instead of `$table` property.