### PR TITLE
Changed buildUniqueExclusionRules to search for 'unique:' rather than 'unique' so that custom rules are not changed

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -786,7 +786,7 @@ abstract class Ardent extends Model {
             $ruleset = (is_string($ruleset))? explode('|', $ruleset) : $ruleset;
 
             foreach ($ruleset as &$rule) {
-              if (strpos($rule, 'unique') === 0) {
+              if (strpos($rule, 'unique:') === 0) {
                 // Stop splitting at 4 so final param will hold optional where clause
                 $params = explode(',', $rule, 4); 
 


### PR DESCRIPTION
Same as issue #231 but doesn't involve all the formatting changes (I'm assuming this may be why it has not been merged sooner).