### PR TITLE
In Ardent\belongsTo function $relation was being over-written with the calling function name.

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -372,13 +372,15 @@ abstract class Ardent extends Model {
 	 * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
 	 */
 	public function belongsTo($related, $foreignKey = NULL, $otherKey = NULL, $relation = NULL) {
-		$backtrace = debug_backtrace(false);
-		$caller = ($backtrace[1]['function'] == 'handleRelationalArray')? $backtrace[3] : $backtrace[1];
 
 		// If no foreign key was supplied, we can use a backtrace to guess the proper
 		// foreign key name by using the name of the relationship function, which
 		// when combined with an "_id" should conventionally match the columns.
-		if(is_null($relation)) $relation = $caller['function'];
+		if (is_null($relation)) {
+			$backtrace = debug_backtrace(false);
+			$caller = ($backtrace[1]['function'] == 'handleRelationalArray')? $backtrace[3] : $backtrace[1];
+			$relation = $caller['function'];
+		}
 
 		if (is_null($foreignKey)) {
 			$foreignKey = snake_case($relation).'_id';

--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -378,7 +378,7 @@ abstract class Ardent extends Model {
 		// If no foreign key was supplied, we can use a backtrace to guess the proper
 		// foreign key name by using the name of the relationship function, which
 		// when combined with an "_id" should conventionally match the columns.
-		$relation = $caller['function'];
+		if(is_null($relation)) $relation = $caller['function'];
 
 		if (is_null($foreignKey)) {
 			$foreignKey = snake_case($relation).'_id';


### PR DESCRIPTION
First time open-source contributor here.. Have been using Ardent for a while, and it's really great! Thank you!

In Ardent\belongsTo function $relation was being over-written with the calling function name. I picked this up when trying to associate a model relationship dynamically via $model->belongsTo($related, $foreignKey, $otherKey, $relation)->associate($relationModel);